### PR TITLE
Update sync-fork.yml

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: tgymnich/fork-sync@v1.9.0
         with:
           owner: apache
-          name: activemq-artemis
-          base: upstream-mirror
+          repo: activemq-artemis
           head: main
+          base: upstream-mirror
           pr_title: Fork Sync with Upstream
+          auto_approve: false
+          # auto_merge: false
+          retries: 2


### PR DESCRIPTION
Attribute `name` was renamed to `repo` in Sync Fork.

```
Warning: Unexpected input(s) 'name', valid inputs are ['owner', 'repo', 'token', 'head', 'base', 'merge_method', 'pr_title', 'pr_message', 'ignore_fail', 'auto_approve', 'auto_merge', 'retries', 'retry_after']
Run tgymnich/fork-sync@v1.9.0
  with:
    owner: apache
    name: activemq-artemis
    base: upstream-mirror
    head: main
    pr_title: Fork Sync with Upstream
    token: ***
    merge_method: merge
    ignore_fail: false
    auto_approve: false
    auto_merge: true
    retries: 4
    retry_after: 60
```